### PR TITLE
Correct misspelling of function name readUNBDateTimeOfPpreperation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Read from EDI file requested segment element values.
 ```php
 $r = new Reader($x);
 $sender = $r->readEdiDataValue('UNB', 2);
-$Dt = $r->readUNBDateTimeOfPpreperation();
+$Dt = $r->readUNBDateTimeOfPreperation();
 
 ```
 Where X could be:
@@ -122,7 +122,7 @@ $c = new Parser($x);
 $r = new Reader();
 $r->setParsedFile($c);
 $sender = $r->readEdiDataValue('UNB', 2);
-$Dt = $r->readUNBDateTimeOfPpreperation();
+$Dt = $r->readUNBDateTimeOfPreperation();
 ```
 
 **OUTPUT**

--- a/src/EDI/Reader.php
+++ b/src/EDI/Reader.php
@@ -311,6 +311,14 @@ class Reader
     }
 
     /**
+     * @deprecated
+     */
+    public function readUNBDateTimeOfPpreperation()
+    {
+        return readUNBDateTimeOfPreperation();
+    }
+
+    /**
      * get message preparation time
      *
      * @return mixed|string

--- a/src/EDI/Reader.php
+++ b/src/EDI/Reader.php
@@ -315,7 +315,7 @@ class Reader
      *
      * @return mixed|string
      */
-    public function readUNBDateTimeOfPpreperation()
+    public function readUNBDateTimeOfPreperation()
     {
 
         //separate date (YYMMDD) and time (HHMM)

--- a/tests/EDITest/ReaderTest.php
+++ b/tests/EDITest/ReaderTest.php
@@ -25,11 +25,11 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('1', $unh1);
     }
 
-    public function testReadUNBDateTimeOfPpreperation()
+    public function testreadUNBDateTimeOfPreperation()
     {
         $r = new Reader(__DIR__ . "/../files/example.edi");
 
-        $Dt = $r->readUNBDateTimeOfPpreperation();
+        $Dt = $r->readUNBDateTimeOfPreperation();
         $this->assertEquals('2094-01-01 09:50:00', $Dt);
     }
 

--- a/tests/EDITest/ReaderTest.php
+++ b/tests/EDITest/ReaderTest.php
@@ -25,7 +25,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('1', $unh1);
     }
 
-    public function testreadUNBDateTimeOfPreperation()
+    public function testReadUNBDateTimeOfPreperation()
     {
         $r = new Reader(__DIR__ . "/../files/example.edi");
 


### PR DESCRIPTION
I believe this should be `readUNBDateTimeOfPreperation` based on https://www.stylusstudio.com/edifact/40100/UNB_.htm unless the extra `p` is meant to dictate something else. 