### PR TITLE
Interpreter - bug fix

### DIFF
--- a/src/EDI/Interpreter.php
+++ b/src/EDI/Interpreter.php
@@ -282,7 +282,12 @@ class Interpreter
                     } else {
                         foreach ($detail as $d_n => $d_detail) {
                             $d_sub_desc_attr =  $sub_details_desc[$d_n]['attributes'];
-                            $jsoncomposite[$d_sub_desc_attr['name']][$d_n] = $d_detail;
+                            if(!isset($jsoncomposite[$d_sub_desc_attr['name']])) // New
+                            	$jsoncomposite[$d_sub_desc_attr['name']] = $d_detail;
+                            else if(is_string($jsoncomposite[$d_sub_desc_attr['name']])) // More data than one string
+                            	$jsoncomposite[$d_sub_desc_attr['name']] = array($jsoncomposite[$d_sub_desc_attr['name']], $d_detail);
+                            else // More and more
+                            	$jsoncomposite[$d_sub_desc_attr['name']][] = $d_detail;
                         }
                     }
                 } else {


### PR DESCRIPTION
Following 2. of https://github.com/sabas/edifact/pull/43
A bug appeared since the previous update, this patch fixes it.
The array index "$d_n" was kept through the different elements.

Example with the following DTM line

> UNA:+.? '
> DTM+186:20160502152800:203'

We had : 
```
datetimeperiod: {
    dateOrTimeOrPeriodFunctionCodeQualifier: [ 2 ],
    dateOrTimeOrPeriodValue: [ "1":201605030000 ],
    dateOrTimeOrPeriodFormatCode: [ "2":203 ],
}
```
instead of 
```
datetimeperiod: {
    dateOrTimeOrPeriodFunctionCodeQualifier: 2,
    dateOrTimeOrPeriodValue: 201605030000,
    dateOrTimeOrPeriodFormatCode: 203,
}
```